### PR TITLE
Updating version to be 1.8 to stay in line of 1.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   influxdb:
-    image: influxdb:latest
+    image: influxdb:1.8
     ports:
       - '8086:8086'
     volumes:


### PR DESCRIPTION
See https://hub.docker.com/_/influxdb
latest updated to InfluxDB 2.x
The latest tag for this image now points to the latest released implementation of InfluxDB 2.x. If you are using the latest tag and would like to stay on the InfluxDB 1.x line, please update your environment to reference the 1.8 tag.